### PR TITLE
feat: 사이드바에 포스트 기여도 캘린더 탭 추가

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,11 @@ __pycache__/
 .venv/
 .venv310/
 settings.json
+
+# Jekyll / Bundler
+_site/
+.jekyll-metadata
+.jekyll-cache/
+.bundle/
+vendor/
+Gemfile.lock

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,80 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Repository Overview
+
+Hybrid repository that combines:
+
+1. **A Jekyll blog** (`hyunul.github.io`) built on the [Chirpy theme](https://github.com/cotes2020/jekyll-theme-chirpy), deployed to GitHub Pages via `.github/workflows/pages-deploy.yml`.
+2. **An LLM-powered blog post generator** — a Flask web app (`web/`) plus a Python package (`blog_generator/`) that calls Gemini or OpenAI to generate new Jekyll posts, save them to `_posts/`, and auto-commit + push.
+3. **A Tistory → Jekyll crawler** (`blog_generator/tistory_crawler.py`) that migrates posts from `https://hyunul.tistory.com/`.
+
+## Commands
+
+### Jekyll site (Ruby)
+
+```bash
+bundle install           # install theme + html-proofer
+bundle exec jekyll s     # local dev server (default: http://127.0.0.1:4000)
+bundle exec jekyll b     # production build -> _site/
+bundle exec htmlproofer _site --disable-external   # same check as CI
+```
+
+CI builds with Ruby 3.3. `JEKYLL_ENV=production` is required for production-only compression (`_config.yml` `compress_html` ignores `development`).
+
+### Blog generator (Python / Flask)
+
+```bash
+pip install -r requirements.txt
+python web/app.py        # Flask dev server on http://127.0.0.1:5000
+```
+
+Flow: `/` enter keywords → `/generate` calls the configured LLM → preview page → `/save` writes `_posts/YYYY-MM-DD-<slug>.md`, then `git add/commit/push` on the current branch (see `web/app.py:_commit_and_push_post`). LLM provider + API key are configured at `/settings` and persisted to `settings.json` (gitignored).
+
+### Tistory crawler
+
+```bash
+python -m blog_generator.tistory_crawler --dry-run                  # preview
+python -m blog_generator.tistory_crawler --start 1 --end 78         # full crawl
+python -m blog_generator.tistory_crawler --download-images          # also fetch images
+```
+
+Writes to `_posts/` and skips titles that already exist (see `load_existing_titles`).
+
+## Architecture
+
+### Post authoring contract (strictly enforced)
+
+Both the LLM generator and the Tistory crawler produce posts that must conform to the rules documented in [2026-03-05-Blog_Post_Format_Guide.md](2026-03-05-Blog_Post_Format_Guide.md). Key invariants that `BlogPostGenerator.validate` checks (`blog_generator/generator.py`):
+
+- Filename: `_posts/YYYY-MM-DD-<slug>.md`
+- Front Matter: `title`, `date` (with `+09:00`), `categories`, `tag` — note the key is singular **`tag`**, not `tags`.
+- Required body sections: `## 서론`, `## 본론`, `## 정리`, `## Reference`.
+- `date` must match the filename date; the generator rewrites `date` to KST *now* before saving (`_ensure_today_date`).
+
+If you change the required sections or Front Matter fields, update the guide, the system prompt (`blog_generator/prompt_template.py`), and `BlogPostGenerator.validate` together — they are coupled.
+
+### Blog generator package (`blog_generator/`)
+
+- `config.py` — `LLMSettings` dataclass, load/save to `settings.json`, default model per provider (`GEMINI` → `gemini-2.0-flash`, `OPENAI` → `gpt-4o-mini`), and `DEFAULT_CATEGORY_TAGS` used as fallback tags.
+- `prompt_template.py` — loads the format guide and builds system + user prompts. The format guide file is the source of truth fed into the LLM.
+- `generator.py` — `BlogPostGenerator.generate/validate/save`. Both Gemini and OpenAI code paths normalize the response (strip fenced ```markdown blocks, force today's KST date) before validation and write.
+- `tistory_crawler.py` — standalone; does not depend on `LLMSettings`. Uses JSON-LD + `window.T.entryInfo` + meta-tag fallbacks to extract metadata, `markdownify` for HTML→MD conversion, and maps Tistory categories to Jekyll categories via `CATEGORY_MAP`.
+
+### Web app (`web/`)
+
+Thin Flask wrapper. `app.py` also executes Git: on `/save` it `git add` the new post, `git commit` with a message derived from the Front Matter title, and `git push` to the current branch. Any change to the save flow must keep this three-step sequence correct — a failed push still leaves the file written and committed locally.
+
+### Jekyll specifics
+
+- `_plugins/posts-lastmod-hook.rb` sets `last_modified_at` from `git log` — GitHub Actions must check out with `fetch-depth: 0` (already configured).
+- `_config.yml` `exclude` omits `web/` from the Jekyll build, so the Flask app does not bleed into the published site.
+- `permalink` for posts is `/posts/:title/`. Don't change without updating internal links.
+- Comments use Giscus (`hyunul/hyunul.github.io`, category `General`).
+
+## Conventions observed in existing posts
+
+- Titles use bracket prefixes: `[spring]`, `[trouble-shooting]`, `[ai]`, `[security]`, `[Blog]`, `[Error]`, etc.
+- Filenames may contain Korean characters and brackets (e.g. `2025-04-17-[spring]-로그는-왜-남기나요.md`). This is expected — the slugifier deliberately preserves non-ASCII.
+- Images live under `assets/images/<slug>/` and are referenced via `<img>` tags rather than Markdown image syntax.

--- a/_layouts/calendar.html
+++ b/_layouts/calendar.html
@@ -1,0 +1,225 @@
+---
+layout: page
+# GitHub-style contribution heatmap for posts.
+---
+
+<style>
+  #calendar-heatmap { display: flex; flex-direction: column; gap: 2.5rem; }
+  .cal-year { overflow-x: auto; }
+  .cal-year-title { font-weight: 600; margin-bottom: 0.75rem; }
+  .cal-year-title .cal-count { font-weight: 400; color: var(--text-muted-color); margin-left: 0.5rem; }
+  .cal-body { display: inline-block; min-width: 100%; }
+  .cal-months { display: grid; grid-template-columns: 2rem repeat(53, 14px); column-gap: 2px; margin-bottom: 4px; font-size: 0.72rem; color: var(--text-muted-color); }
+  .cal-months .cal-month-label { grid-row: 1; white-space: nowrap; }
+  .cal-row { display: grid; grid-template-columns: 2rem repeat(53, 14px); column-gap: 2px; margin-bottom: 2px; }
+  .cal-day-label { font-size: 0.72rem; color: var(--text-muted-color); line-height: 14px; height: 14px; }
+  .cal-cell { width: 14px; height: 14px; border-radius: 2px; background: #ebedf0; }
+  .cal-cell.cal-outside { background: transparent; }
+  .cal-cell[data-level="1"] { background: #9be9a8; }
+  .cal-cell[data-level="2"] { background: #40c463; }
+  .cal-cell[data-level="3"] { background: #30a14e; }
+  .cal-cell[data-level="4"] { background: #216e39; }
+  .cal-cell.cal-has-post { cursor: pointer; }
+  .cal-cell.cal-has-post:hover { outline: 1px solid var(--text-color); outline-offset: 1px; }
+  html[data-mode="dark"] .cal-cell { background: #161b22; }
+  html[data-mode="dark"] .cal-cell[data-level="1"] { background: #0e4429; }
+  html[data-mode="dark"] .cal-cell[data-level="2"] { background: #006d32; }
+  html[data-mode="dark"] .cal-cell[data-level="3"] { background: #26a641; }
+  html[data-mode="dark"] .cal-cell[data-level="4"] { background: #39d353; }
+  .cal-legend { display: flex; align-items: center; gap: 6px; font-size: 0.8rem; color: var(--text-muted-color); margin-top: 0.5rem; }
+  .cal-legend .cal-cell { width: 12px; height: 12px; }
+  .cal-tip { position: fixed; z-index: 50; background: var(--card-bg, #fff); color: var(--text-color); border: 1px solid var(--border-color, rgba(128,128,128,0.3)); border-radius: 6px; padding: 0.5rem 0.7rem; font-size: 0.82rem; box-shadow: 0 4px 12px rgba(0,0,0,0.12); pointer-events: none; max-width: 280px; display: none; }
+  .cal-tip .cal-tip-date { font-weight: 600; margin-bottom: 0.25rem; }
+  .cal-tip ul { list-style: disc; padding-left: 1.1rem; margin: 0; }
+</style>
+
+<div id="calendar-heatmap" class="pl-xl-3">Loading calendar…</div>
+<div id="cal-tip" class="cal-tip" role="tooltip" aria-hidden="true"></div>
+
+<script id="calendar-data" type="application/json">
+{
+{%- assign posts_by_day = site.posts | group_by_exp: "post", "post.date | date: '%Y-%m-%d'" -%}
+{%- for group in posts_by_day -%}
+  {%- unless forloop.first %},{% endunless -%}
+  "{{ group.name }}": [
+  {%- for post in group.items -%}
+    {%- unless forloop.first %},{% endunless -%}
+    {"title": {{ post.title | jsonify }}, "url": {{ post.url | relative_url | jsonify }}}
+  {%- endfor -%}
+  ]
+{%- endfor -%}
+}
+</script>
+
+<script>
+(function () {
+  var raw = document.getElementById('calendar-data').textContent;
+  var data;
+  try { data = JSON.parse(raw); } catch (e) { data = {}; }
+
+  var container = document.getElementById('calendar-heatmap');
+  var tip = document.getElementById('cal-tip');
+  var keys = Object.keys(data).sort();
+  container.innerHTML = '';
+
+  if (!keys.length) {
+    container.textContent = 'No posts yet.';
+    return;
+  }
+
+  var MONTHS = ['Jan','Feb','Mar','Apr','May','Jun','Jul','Aug','Sep','Oct','Nov','Dec'];
+  var minYear = parseInt(keys[0].slice(0, 4), 10);
+  var maxYear = Math.max(
+    parseInt(keys[keys.length - 1].slice(0, 4), 10),
+    new Date().getFullYear()
+  );
+
+  for (var y = maxYear; y >= minYear; y--) {
+    container.appendChild(renderYear(y));
+  }
+  container.appendChild(renderLegend());
+
+  function renderYear(year) {
+    var section = document.createElement('section');
+    section.className = 'cal-year';
+
+    var total = 0;
+    for (var k in data) {
+      if (data.hasOwnProperty(k) && k.indexOf(year + '-') === 0) total += data[k].length;
+    }
+
+    var title = document.createElement('h3');
+    title.className = 'cal-year-title';
+    title.textContent = year;
+    var count = document.createElement('span');
+    count.className = 'cal-count';
+    count.textContent = total + ' post' + (total === 1 ? '' : 's');
+    title.appendChild(count);
+    section.appendChild(title);
+
+    var body = document.createElement('div');
+    body.className = 'cal-body';
+
+    var start = new Date(year, 0, 1);
+    var cursor = new Date(year, 0, 1);
+    cursor.setDate(cursor.getDate() - start.getDay()); // back to Sunday
+    var weeks = [];
+    while (cursor.getFullYear() < year || cursor.getMonth() <= 11) {
+      var week = [];
+      for (var d = 0; d < 7; d++) {
+        week.push(new Date(cursor));
+        cursor.setDate(cursor.getDate() + 1);
+      }
+      weeks.push(week);
+      if (cursor.getFullYear() > year) break;
+    }
+
+    var monthRow = document.createElement('div');
+    monthRow.className = 'cal-months';
+    var spacer = document.createElement('span');
+    monthRow.appendChild(spacer);
+    var lastMonth = -1;
+    weeks.forEach(function (week, wi) {
+      var label = document.createElement('span');
+      label.className = 'cal-month-label';
+      label.style.gridColumn = (wi + 2) + ' / span 1';
+      var firstInYear = week.find(function (d) { return d.getFullYear() === year; });
+      if (firstInYear && firstInYear.getDate() <= 7 && firstInYear.getMonth() !== lastMonth) {
+        label.textContent = MONTHS[firstInYear.getMonth()];
+        lastMonth = firstInYear.getMonth();
+      }
+      monthRow.appendChild(label);
+    });
+    body.appendChild(monthRow);
+
+    var dayNames = ['', 'Mon', '', 'Wed', '', 'Fri', ''];
+    for (var r = 0; r < 7; r++) {
+      var row = document.createElement('div');
+      row.className = 'cal-row';
+      var lbl = document.createElement('span');
+      lbl.className = 'cal-day-label';
+      lbl.textContent = dayNames[r];
+      row.appendChild(lbl);
+      weeks.forEach(function (week) {
+        var cell = document.createElement('span');
+        cell.className = 'cal-cell';
+        var day = week[r];
+        if (day.getFullYear() !== year) {
+          cell.classList.add('cal-outside');
+        } else {
+          var iso = toISO(day);
+          var posts = data[iso];
+          if (posts && posts.length) {
+            cell.classList.add('cal-has-post');
+            cell.setAttribute('data-level', Math.min(4, posts.length));
+            cell.setAttribute('data-date', iso);
+            cell.addEventListener('mouseenter', function (e) { showTip(e.currentTarget, iso, posts); });
+            cell.addEventListener('mouseleave', hideTip);
+            cell.addEventListener('click', function () {
+              if (posts.length === 1) window.location.href = posts[0].url;
+              else window.location.href = posts[0].url;
+            });
+          } else {
+            cell.setAttribute('data-level', 0);
+          }
+        }
+        row.appendChild(cell);
+      });
+      body.appendChild(row);
+    }
+
+    section.appendChild(body);
+    return section;
+  }
+
+  function renderLegend() {
+    var wrap = document.createElement('div');
+    wrap.className = 'cal-legend';
+    wrap.appendChild(text('Less'));
+    [0, 1, 2, 3, 4].forEach(function (lv) {
+      var c = document.createElement('span');
+      c.className = 'cal-cell';
+      c.setAttribute('data-level', lv);
+      wrap.appendChild(c);
+    });
+    wrap.appendChild(text('More'));
+    return wrap;
+  }
+
+  function text(t) { var s = document.createElement('span'); s.textContent = t; return s; }
+
+  function toISO(d) {
+    var y = d.getFullYear();
+    var m = String(d.getMonth() + 1).padStart(2, '0');
+    var day = String(d.getDate()).padStart(2, '0');
+    return y + '-' + m + '-' + day;
+  }
+
+  function showTip(cell, iso, posts) {
+    var html = '<div class="cal-tip-date">' + iso + ' · ' + posts.length + ' post' + (posts.length > 1 ? 's' : '') + '</div>';
+    html += '<ul>';
+    posts.forEach(function (p) {
+      var a = document.createElement('a');
+      a.href = p.url;
+      a.textContent = p.title;
+      html += '<li>' + a.outerHTML + '</li>';
+    });
+    html += '</ul>';
+    tip.innerHTML = html;
+    var rect = cell.getBoundingClientRect();
+    tip.style.display = 'block';
+    var top = rect.bottom + 6;
+    var left = rect.left;
+    var tipRect = tip.getBoundingClientRect();
+    if (left + tipRect.width > window.innerWidth - 8) left = window.innerWidth - tipRect.width - 8;
+    tip.style.top = top + 'px';
+    tip.style.left = left + 'px';
+    tip.setAttribute('aria-hidden', 'false');
+  }
+
+  function hideTip() {
+    tip.style.display = 'none';
+    tip.setAttribute('aria-hidden', 'true');
+  }
+})();
+</script>

--- a/_tabs/about.md
+++ b/_tabs/about.md
@@ -1,7 +1,7 @@
 ---
 # the default layout is 'page'
 icon: fas fa-info-circle
-order: 4
+order: 5
 ---
 
 {: .prompt-tip }

--- a/_tabs/archives.md
+++ b/_tabs/archives.md
@@ -1,5 +1,5 @@
 ---
 layout: archives
 icon: fas fa-archive
-order: 3
+order: 4
 ---

--- a/_tabs/calendar.md
+++ b/_tabs/calendar.md
@@ -1,0 +1,6 @@
+---
+title: Calendar
+layout: calendar
+icon: fas fa-calendar-alt
+order: 3
+---


### PR DESCRIPTION
## Summary
- 사이드바 3번째 탭으로 **Calendar** 추가 — GitHub 기여 히트맵 스타일로 일자별 포스팅 현황을 한눈에.
- 연도별로 7×53 그리드를 렌더링, 포스트 수에 따라 4단계 색상. hover 시 날짜/제목 툴팁, 클릭 시 해당 포스트 이동.
- `_tabs/archives.md`, `_tabs/about.md`는 각각 order 4, 5로 밀어냄.
- 부수 변경: 리포지토리 가이드 `CLAUDE.md` 추가, `.gitignore`에 Jekyll 빌드 산출물 추가.

## 구현 포인트
- Liquid가 빌드 타임에 `{YYYY-MM-DD: [{title,url}]}` JSON을 `<script type="application/json">`으로 주입 → 클라이언트 JS가 연도별 히트맵 생성.
- 다크/라이트 모드 팔레트 분리 (`html[data-mode="dark"]` 분기).
- 외부 의존성 없음, 순수 Vanilla JS + CSS.

## Test plan
- [x] `bundle exec jekyll serve`로 로컬 렌더 확인 (http://127.0.0.1:4000/calendar/)
- [x] 사이드바 순서 `HOME / CATEGORIES / TAGS / CALENDAR / ARCHIVES / ABOUT` 검증
- [x] JSON 데이터에 전 포스트(2024~2026) 포함 확인
- [ ] GitHub Pages 배포 후 라이브 히트맵 확인
- [ ] 다크모드 전환 시 색상 팔레트 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)