### PR TITLE
fix(calendar): 툴팁 내 링크 클릭 가능하도록 hover 유지

### DIFF
--- a/_layouts/calendar.html
+++ b/_layouts/calendar.html
@@ -28,9 +28,11 @@ layout: page
   html[data-mode="dark"] .cal-cell[data-level="4"] { background: #39d353; }
   .cal-legend { display: flex; align-items: center; gap: 6px; font-size: 0.8rem; color: var(--text-muted-color); margin-top: 0.5rem; }
   .cal-legend .cal-cell { width: 12px; height: 12px; }
-  .cal-tip { position: fixed; z-index: 50; background: var(--card-bg, #fff); color: var(--text-color); border: 1px solid var(--border-color, rgba(128,128,128,0.3)); border-radius: 6px; padding: 0.5rem 0.7rem; font-size: 0.82rem; box-shadow: 0 4px 12px rgba(0,0,0,0.12); pointer-events: none; max-width: 280px; display: none; }
+  .cal-tip { position: fixed; z-index: 50; background: var(--card-bg, #fff); color: var(--text-color); border: 1px solid var(--border-color, rgba(128,128,128,0.3)); border-radius: 6px; padding: 0.5rem 0.7rem; font-size: 0.82rem; box-shadow: 0 4px 12px rgba(0,0,0,0.12); max-width: 280px; display: none; }
   .cal-tip .cal-tip-date { font-weight: 600; margin-bottom: 0.25rem; }
   .cal-tip ul { list-style: disc; padding-left: 1.1rem; margin: 0; }
+  .cal-tip a { color: var(--link-color, #2a7ae2); text-decoration: none; }
+  .cal-tip a:hover { text-decoration: underline; }
 </style>
 
 <div id="calendar-heatmap" class="pl-xl-3">Loading calendar…</div>
@@ -154,10 +156,9 @@ layout: page
             cell.setAttribute('data-level', Math.min(4, posts.length));
             cell.setAttribute('data-date', iso);
             cell.addEventListener('mouseenter', function (e) { showTip(e.currentTarget, iso, posts); });
-            cell.addEventListener('mouseleave', hideTip);
+            cell.addEventListener('mouseleave', scheduleHide);
             cell.addEventListener('click', function () {
               if (posts.length === 1) window.location.href = posts[0].url;
-              else window.location.href = posts[0].url;
             });
           } else {
             cell.setAttribute('data-level', 0);
@@ -195,7 +196,10 @@ layout: page
     return y + '-' + m + '-' + day;
   }
 
+  var hideTimer = null;
+
   function showTip(cell, iso, posts) {
+    cancelHide();
     var html = '<div class="cal-tip-date">' + iso + ' · ' + posts.length + ' post' + (posts.length > 1 ? 's' : '') + '</div>';
     html += '<ul>';
     posts.forEach(function (p) {
@@ -221,5 +225,17 @@ layout: page
     tip.style.display = 'none';
     tip.setAttribute('aria-hidden', 'true');
   }
+
+  function scheduleHide() {
+    cancelHide();
+    hideTimer = setTimeout(hideTip, 180);
+  }
+
+  function cancelHide() {
+    if (hideTimer) { clearTimeout(hideTimer); hideTimer = null; }
+  }
+
+  tip.addEventListener('mouseenter', cancelHide);
+  tip.addEventListener('mouseleave', scheduleHide);
 })();
 </script>


### PR DESCRIPTION
## Summary
캘린더 히트맵 셀의 툴팁에서 글 제목을 클릭하려고 하면 툴팁이 사라져 클릭이 안 되던 버그 수정.

## 변경
- 툴팁에서 `pointer-events: none` 제거 → 내부 요소 클릭/호버 가능
- 셀 `mouseleave` 시 즉시 숨기지 않고 **180ms 지연 숨김**. 그 사이 마우스가 툴팁으로 이동하면 취소.
- 툴팁 자체에도 `mouseenter`/`mouseleave` 등록하여 유지/재숨김
- 날짜에 포스트가 여러 개인 경우 셀 클릭 시 자동 이동 제거 — 사용자가 리스트에서 선택
- 툴팁 링크 색상/hover 밑줄 스타일 추가

## Test plan
- [x] 셀 hover → 툴팁 등장 후 툴팁 영역으로 커서 이동 → 툴팁 유지
- [x] 툴팁 내 링크 클릭 → 해당 포스트로 정상 이동
- [x] 툴팁에서 벗어나면 짧은 지연 뒤 사라짐

🤖 Generated with [Claude Code](https://claude.com/claude-code)