### PR TITLE
fix(calendar): compress_html로 인한 인라인 JS 파싱 실패 수정

### DIFF
--- a/_layouts/calendar.html
+++ b/_layouts/calendar.html
@@ -104,7 +104,7 @@ layout: page
 
     var start = new Date(year, 0, 1);
     var cursor = new Date(year, 0, 1);
-    cursor.setDate(cursor.getDate() - start.getDay()); // back to Sunday
+    cursor.setDate(cursor.getDate() - start.getDay()); /* back to Sunday */
     var weeks = [];
     while (cursor.getFullYear() < year || cursor.getMonth() <= 11) {
       var week = [];
@@ -206,7 +206,7 @@ layout: page
       var a = document.createElement('a');
       a.href = p.url;
       a.textContent = p.title;
-      html += '<li>' + a.outerHTML + '</li>';
+      html += '<li>' + a.outerHTML + '</' + 'li>';
     });
     html += '</ul>';
     tip.innerHTML = html;


### PR DESCRIPTION
## Summary
- `/calendar/` 페이지가 "Loading calendar…"에서 멈추는 버그 수정.
- **근본 원인**: `_config.yml`의 `compress_html` 설정(`endings: all`, 개행 제거)이 인라인 `<script>` 내용을 건드려 두 가지 버그를 유발했음.
  1. `// back to Sunday` 라인 주석이 개행 제거 후 IIFE의 나머지 전체를 주석 처리 → `SyntaxError: Unexpected end of input`.
  2. 문자열 리터럴 `'</li>'`를 optional HTML 태그로 오인해 제거 → 툴팁 마크업 깨짐.
- **수정**: `//` → `/* */` 블록 주석, `'</li>'` → `'</' + 'li>'` 분할.

## Test plan
- [x] `JEKYLL_ENV=production bundle exec jekyll b` 빌드 후 `_site/calendar/index.html`의 IIFE가 `vm.Script`로 정상 파싱 (`SCRIPT PARSE: OK`)
- [x] 압축 산출물에 `</li>` 문자열 리터럴 보존 확인
- [ ] 배포 후 라이브 사이트 `/calendar/` 에서 히트맵 렌더링 확인
- [ ] 툴팁 hover 시 포스트 링크 클릭 가능 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)